### PR TITLE
Implement 7x6 MedChess game with RL bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+model.zip

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# MedChess Python
+
+Ce projet implémente un jeu inspiré des échecs sur une grille 7x6 avec des pièces personnalisées.
+Un bot basé sur l'apprentissage par renforcement (DQN) est fourni pour affronter le joueur humain.
+
+## Installation
+
+Installez les dépendances avec `pip` :
+
+```bash
+pip install -r requirements.txt
+```
+
+## Lancement d'une partie
+
+```bash
+python -m medchess.game
+```
+
+Le joueur humain dispose de 30 secondes pour saisir un coup sous la forme :
+
+```
+fr fc tr tc
+```
+
+Où `fr`/`fc` représentent la case de départ et `tr`/`tc` la case d'arrivée (indices de 0 à 5 pour les lignes et de 0 à 6 pour les colonnes).
+Si le temps imparti est dépassé ou si un coup invalide est joué, la partie est perdue.
+
+Le modèle du bot est entraîné automatiquement si aucun fichier `model.zip` n'est présent.

--- a/medchess/ai.py
+++ b/medchess/ai.py
@@ -1,0 +1,97 @@
+import os
+from typing import Optional
+
+import gym
+import numpy as np
+from stable_baselines3 import DQN
+from stable_baselines3.dqn import MlpPolicy
+
+from .board import Board, Move, BOARD_HEIGHT, BOARD_WIDTH
+from .rules import legal_moves
+from .pieces import PieceType
+
+class MedChessEnv(gym.Env):
+    metadata = {'render.modes': ['human']}
+    def __init__(self):
+        super().__init__()
+        self.board = Board()
+        self.current_player = 0
+        self.action_space = gym.spaces.Discrete(BOARD_WIDTH * BOARD_HEIGHT * BOARD_WIDTH * BOARD_HEIGHT)
+        self.observation_space = gym.spaces.Box(low=0, high=8, shape=(BOARD_HEIGHT, BOARD_WIDTH), dtype=np.int8)
+        self.done = False
+
+    def reset(self):
+        self.board.reset()
+        self.current_player = 0
+        self.done = False
+        return self._get_obs()
+
+    def _get_obs(self):
+        arr = np.zeros((BOARD_HEIGHT, BOARD_WIDTH), dtype=np.int8)
+        for r in range(BOARD_HEIGHT):
+            for c in range(BOARD_WIDTH):
+                piece = self.board.get_piece(r, c)
+                if piece:
+                    code = {
+                        PieceType.SWORDSMAN: 1,
+                        PieceType.KNIGHT: 2,
+                        PieceType.GENERAL: 3,
+                        PieceType.CASTLE: 4,
+                    }[piece.type]
+                    arr[r, c] = code if piece.player == 0 else code + 4
+        return arr
+
+    def step(self, action: int):
+        if self.done:
+            return self._get_obs(), 0.0, True, {}
+        move = self._decode_action(action)
+        if move not in legal_moves(self.board, self.current_player):
+            self.done = True
+            return self._get_obs(), -1.0, True, {}
+        fr, fc, tr, tc = move
+        target = self.board.get_piece(tr, tc)
+        self.board.move_piece(move)
+        reward = 0.0
+        if target and target.type == PieceType.CASTLE:
+            self.done = True
+            reward = 1.0
+        self.current_player = 1 - self.current_player
+        return self._get_obs(), reward, self.done, {}
+
+    def render(self, mode='human'):
+        print(self.board.render())
+
+    def _decode_action(self, action: int) -> Move:
+        fr = action // (BOARD_WIDTH * BOARD_WIDTH * BOARD_HEIGHT)
+        action %= BOARD_WIDTH * BOARD_WIDTH * BOARD_HEIGHT
+        fc = action // (BOARD_WIDTH * BOARD_HEIGHT)
+        action %= BOARD_WIDTH * BOARD_HEIGHT
+        tr = action // BOARD_WIDTH
+        tc = action % BOARD_WIDTH
+        return fr, fc, tr, tc
+
+
+def train(path: str, timesteps: int = 10000) -> None:
+    env = MedChessEnv()
+    model = DQN(MlpPolicy, env, verbose=0)
+    model.learn(total_timesteps=timesteps)
+    model.save(path)
+
+class AIPlayer:
+    def __init__(self, model_path: str):
+        if os.path.exists(model_path):
+            self.model = DQN.load(model_path)
+        else:
+            train(model_path, 1000)
+            self.model = DQN.load(model_path)
+        self.env = MedChessEnv()
+
+    def choose_move(self, board: Board, player: int) -> Optional[Move]:
+        self.env.board = board.copy()
+        self.env.current_player = player
+        state = self.env._get_obs()
+        action, _ = self.model.predict(state, deterministic=True)
+        move = self.env._decode_action(int(action))
+        if move in legal_moves(board, player):
+            return move
+        return None

--- a/medchess/board.py
+++ b/medchess/board.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from .pieces import Piece, PieceType
+
+BOARD_WIDTH = 7
+BOARD_HEIGHT = 6
+
+Move = Tuple[int, int, int, int]  # from_row, from_col, to_row, to_col
+
+@dataclass
+class Cell:
+    piece: Optional[Piece] = None
+
+class Board:
+    def __init__(self) -> None:
+        self.grid: List[List[Cell]] = [
+            [Cell() for _ in range(BOARD_WIDTH)] for _ in range(BOARD_HEIGHT)
+        ]
+        self.reset()
+
+    def reset(self) -> None:
+        # Clear board
+        for row in self.grid:
+            for cell in row:
+                cell.piece = None
+        # Setup initial pieces
+        setup = [
+            Piece(PieceType.SWORDSMAN, 0),
+            Piece(PieceType.SWORDSMAN, 0),
+            Piece(PieceType.GENERAL, 0),
+            Piece(PieceType.CASTLE, 0),
+            Piece(PieceType.GENERAL, 0),
+            Piece(PieceType.SWORDSMAN, 0),
+            Piece(PieceType.SWORDSMAN, 0),
+        ]
+        for c, piece in enumerate(setup):
+            self.grid[0][c].piece = piece
+            self.grid[BOARD_HEIGHT - 1][c].piece = Piece(piece.type, 1)
+
+    def in_bounds(self, r: int, c: int) -> bool:
+        return 0 <= r < BOARD_HEIGHT and 0 <= c < BOARD_WIDTH
+
+    def get_piece(self, r: int, c: int) -> Optional[Piece]:
+        return self.grid[r][c].piece if self.in_bounds(r, c) else None
+
+    def move_piece(self, move: Move) -> bool:
+        fr, fc, tr, tc = move
+        if not (self.in_bounds(fr, fc) and self.in_bounds(tr, tc)):
+            return False
+        piece = self.get_piece(fr, fc)
+        if not piece:
+            return False
+        target = self.get_piece(tr, tc)
+        if target and target.player == piece.player:
+            return False
+        self.grid[tr][tc].piece = piece
+        self.grid[fr][fc].piece = None
+        return True
+
+    def copy(self) -> "Board":
+        b = Board()
+        for r in range(BOARD_HEIGHT):
+            for c in range(BOARD_WIDTH):
+                piece = self.get_piece(r, c)
+                if piece:
+                    b.grid[r][c].piece = Piece(piece.type, piece.player)
+                else:
+                    b.grid[r][c].piece = None
+        return b
+
+    def render(self) -> str:
+        rows = []
+        for r in range(BOARD_HEIGHT):
+            row = []
+            for c in range(BOARD_WIDTH):
+                piece = self.get_piece(r, c)
+                row.append(piece.__repr__() if piece else "..")
+            rows.append(" ".join(row))
+        return "\n".join(rows)

--- a/medchess/game.py
+++ b/medchess/game.py
@@ -1,0 +1,66 @@
+import os
+import signal
+from typing import Optional
+
+from .board import Board
+from .rules import legal_moves
+from .ai import AIPlayer
+
+TIME_LIMIT = 30
+
+class TimeoutException(Exception):
+    pass
+
+def _timeout_handler(signum, frame):
+    raise TimeoutException()
+
+def timed_input(prompt: str, timeout: int) -> str:
+    signal.signal(signal.SIGALRM, _timeout_handler)
+    signal.alarm(timeout)
+    try:
+        return input(prompt)
+    finally:
+        signal.alarm(0)
+
+def parse_move(text: str) -> Optional[tuple[int, int, int, int]]:
+    try:
+        fr, fc, tr, tc = map(int, text.strip().split())
+        return fr, fc, tr, tc
+    except Exception:
+        return None
+
+def play() -> None:
+    board = Board()
+    ai = AIPlayer(os.path.join(os.path.dirname(__file__), 'model.zip'))
+    current_player = 0
+    while True:
+        print(board.render())
+        if current_player == 0:
+            try:
+                user_move = timed_input('Votre coup (fr fc tr tc): ', TIME_LIMIT)
+            except TimeoutException:
+                print('Temps écoulé ! Vous avez perdu.')
+                return
+            move = parse_move(user_move)
+            if move is None or move not in legal_moves(board, current_player):
+                print('Coup invalide, vous avez perdu.')
+                return
+            fr, fc, tr, tc = move
+            target = board.get_piece(tr, tc)
+            board.move_piece(move)
+            if target and target.type.value == 'C':
+                print('Vous avez capturé le chateau adverse. Vous gagnez !')
+                return
+        else:
+            move = ai.choose_move(board, current_player)
+            if move is None:
+                print('Le bot ne peut jouer. Vous gagnez !')
+                return
+            fr, fc, tr, tc = move
+            print(f'Bot joue: {fr} {fc} {tr} {tc}')
+            target = board.get_piece(tr, tc)
+            board.move_piece(move)
+            if target and target.type.value == 'C':
+                print('Le bot capture votre chateau. Vous perdez !')
+                return
+        current_player = 1 - current_player

--- a/medchess/pieces.py
+++ b/medchess/pieces.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+class PieceType(Enum):
+    SWORDSMAN = "S"
+    KNIGHT = "N"
+    GENERAL = "G"
+    CASTLE = "C"
+
+class Piece:
+    def __init__(self, piece_type: PieceType, player: int):
+        self.type = piece_type
+        self.player = player  # 0 or 1
+
+    def __repr__(self):
+        return f"{self.type.value}{self.player}"

--- a/medchess/rules.py
+++ b/medchess/rules.py
@@ -1,0 +1,61 @@
+from typing import List
+
+from .board import Board, Move, BOARD_HEIGHT, BOARD_WIDTH
+from .pieces import PieceType
+
+# Directions for swordsman (orthogonal)
+ORTHO_DIRS = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+# Directions for knight (diagonal one step)
+DIAG_DIRS = [(-1, -1), (-1, 1), (1, -1), (1, 1)]
+
+def legal_moves(board: Board, player: int) -> List[Move]:
+    moves: List[Move] = []
+    for r in range(BOARD_HEIGHT):
+        for c in range(BOARD_WIDTH):
+            piece = board.get_piece(r, c)
+            if piece is None or piece.player != player:
+                continue
+            if piece.type == PieceType.SWORDSMAN:
+                moves.extend(_orthogonal_moves(board, r, c, 1))
+            elif piece.type == PieceType.KNIGHT:
+                moves.extend(_diagonal_moves(board, r, c, 1))
+            elif piece.type == PieceType.GENERAL:
+                moves.extend(_orthogonal_moves(board, r, c, 2))
+                moves.extend(_diagonal_moves(board, r, c, 1))
+            elif piece.type == PieceType.CASTLE:
+                continue
+    return moves
+
+def _orthogonal_moves(board: Board, r: int, c: int, distance: int) -> List[Move]:
+    moves = []
+    for dr, dc in ORTHO_DIRS:
+        for i in range(1, distance + 1):
+            tr, tc = r + dr * i, c + dc * i
+            if not board.in_bounds(tr, tc):
+                break
+            target = board.get_piece(tr, tc)
+            if target is None:
+                moves.append((r, c, tr, tc))
+            elif target.player != board.get_piece(r, c).player:
+                moves.append((r, c, tr, tc))
+                break
+            else:
+                break
+    return moves
+
+def _diagonal_moves(board: Board, r: int, c: int, distance: int) -> List[Move]:
+    moves = []
+    for dr, dc in DIAG_DIRS:
+        for i in range(1, distance + 1):
+            tr, tc = r + dr * i, c + dc * i
+            if not board.in_bounds(tr, tc):
+                break
+            target = board.get_piece(tr, tc)
+            if target is None:
+                moves.append((r, c, tr, tc))
+            elif target.player != board.get_piece(r, c).player:
+                moves.append((r, c, tr, tc))
+                break
+            else:
+                break
+    return moves

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+stable-baselines3
+gym
+numpy
+torch
+shimmy>=2.0


### PR DESCRIPTION
## Summary
- create a `medchess` package implementing a 7x6 board game
- add piece movement rules and board setup
- include a DQN-based AI player using Stable Baselines3
- provide a CLI game loop with 30s per move
- document installation and execution steps
- add dependency list and .gitignore

## Testing
- `python -m py_compile medchess/*.py`
- `pip install -r requirements.txt`
- `pip install shimmy>=2.0`

------
https://chatgpt.com/codex/tasks/task_e_68443836d9e883268946c97e58c6fda1