### PR TITLE
Fix AI fallback move selection

### DIFF
--- a/medchess/ai.py
+++ b/medchess/ai.py
@@ -1,4 +1,5 @@
 import os
+import random
 from typing import Optional
 
 import gym
@@ -94,4 +95,8 @@ class AIPlayer:
         move = self.env._decode_action(int(action))
         if move in legal_moves(board, player):
             return move
+        # If the predicted move is illegal, fall back to a random legal move
+        moves = legal_moves(board, player)
+        if moves:
+            return random.choice(moves)
         return None


### PR DESCRIPTION
## Summary
- add random fallback move to `AIPlayer` when model predicts an illegal move

## Testing
- `pip install -r requirements.txt`
- `python -m medchess.game` (fails in testing due to interactive requirements)

------
https://chatgpt.com/codex/tasks/task_e_68443d9cae148326a0ab4ec876a417a4