### PR TITLE
Add configurable AI depth and time

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ pip install -r requirements.txt
 ## Lancement d'une partie
 
 ```bash
-python -m medchess.game
+python -m medchess.game [-power N] [-max SECONDES]
 ```
+`power` contrôle la profondeur de recherche du bot (1 à 10) et `max` le temps de réflexion maximum en secondes (30 par défaut).
 
 Le joueur humain dispose de 30 secondes pour saisir un coup sous la forme :
 
@@ -33,5 +34,6 @@ Le modèle du bot est entraîné automatiquement si aucun fichier `model.zip` n'
 Une interface utilisant Tkinter permet de jouer de façon visuelle. Lancez-la avec :
 
 ```bash
-python -m medchess.gui
+python -m medchess.gui [-power N] [-max SECONDES]
 ```
+Les mêmes options `power` et `max` sont disponibles pour ajuster la force du bot.

--- a/medchess/game.py
+++ b/medchess/game.py
@@ -29,7 +29,7 @@ def parse_move(text: str) -> Optional[tuple[int, int, int, int]]:
     except Exception:
         return None
 
-def play() -> None:
+def play(power: int = 1, max_time: int = TIME_LIMIT) -> None:
     board = Board()
     ai = AIPlayer(os.path.join(os.path.dirname(__file__), 'model.zip'))
     current_player = 0
@@ -37,7 +37,7 @@ def play() -> None:
         print(board.render())
         if current_player == 0:
             try:
-                user_move = timed_input('Votre coup (fr fc tr tc): ', TIME_LIMIT)
+                user_move = timed_input('Votre coup (fr fc tr tc): ', max_time)
             except TimeoutException:
                 print('Temps écoulé ! Vous avez perdu.')
                 return
@@ -52,7 +52,7 @@ def play() -> None:
                 print('Vous avez capturé le chateau adverse. Vous gagnez !')
                 return
         else:
-            move = ai.choose_move(board, current_player)
+            move = ai.choose_move(board, current_player, power=power, max_time=max_time)
             if move is None:
                 print('Le bot ne peut jouer. Vous gagnez !')
                 return
@@ -64,3 +64,13 @@ def play() -> None:
                 print('Le bot capture votre chateau. Vous perdez !')
                 return
         current_player = 1 - current_player
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Play MedChess in the terminal")
+    parser.add_argument("-power", type=int, default=1, help="Profondeur de recherche de l'IA (1-10)")
+    parser.add_argument("-max", type=int, default=TIME_LIMIT, help="Temps de réflexion maximum en secondes")
+    args = parser.parse_args()
+
+    play(power=args.power, max_time=args.max)

--- a/medchess/gui.py
+++ b/medchess/gui.py
@@ -10,7 +10,7 @@ from .ai import AIPlayer
 CELL_SIZE = 60
 
 class GameGUI(tk.Tk):
-    def __init__(self) -> None:
+    def __init__(self, power: int = 1, max_time: int = 30) -> None:
         super().__init__()
         self.title("MedChess")
         self.resizable(False, False)
@@ -18,6 +18,8 @@ class GameGUI(tk.Tk):
         self.board = Board()
         model_path = os.path.join(os.path.dirname(__file__), 'model.zip')
         self.ai = AIPlayer(model_path)
+        self.power = power
+        self.max_time = max_time
         self.current_player = 0
         self.selected = None
 
@@ -87,7 +89,7 @@ class GameGUI(tk.Tk):
         self.draw_board()
 
     def ai_move(self) -> None:
-        move = self.ai.choose_move(self.board, 1)
+        move = self.ai.choose_move(self.board, 1, power=self.power, max_time=self.max_time)
         if move is None:
             messagebox.showinfo("Victoire", "Le bot ne peut jouer. Vous gagnez !")
             self.destroy()
@@ -103,10 +105,17 @@ class GameGUI(tk.Tk):
         self.draw_board()
 
 
-def play_gui() -> None:
-    app = GameGUI()
+def play_gui(power: int = 1, max_time: int = 30) -> None:
+    app = GameGUI(power=power, max_time=max_time)
     app.mainloop()
 
 if __name__ == "__main__":
-    play_gui()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interface graphique de MedChess")
+    parser.add_argument("-power", type=int, default=1, help="Profondeur de recherche de l'IA (1-10)")
+    parser.add_argument("-max", type=int, default=30, help="Temps de réflexion maximum en secondes")
+    args = parser.parse_args()
+
+    play_gui(power=args.power, max_time=args.max)
 


### PR DESCRIPTION
## Summary
- implement search-based AI with depth and time control
- expose `-power` and `-max` options for CLI and GUI
- document usage in README

## Testing
- `python -m py_compile medchess/ai.py medchess/game.py medchess/gui.py`
- `python -m medchess.game -h` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_6844400d28f48326a19f7d9a9cf87260