### PR TITLE
Add new board layout and AI personalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ce projet implémente un jeu inspiré des échecs sur une grille 7x6 avec des pièces personnalisées.
 Un bot basé sur l'apprentissage par renforcement (DQN) est fourni pour affronter le joueur humain.
+Le plateau débute avec, côté IA, deux rangées de pièces : des chevaliers encadrant un général, un château et un second général, puis une ligne d'épéistes. Le joueur dispose de la même formation en bas du plateau.
+L'IA choisit au hasard une personnalité (Aggressive, Équilibré ou Défensif) qui oriente ses premiers coups grâce à de petites ouvertures prédéfinies.
 
 ## Installation
 

--- a/medchess/board.py
+++ b/medchess/board.py
@@ -27,18 +27,24 @@ class Board:
             for cell in row:
                 cell.piece = None
         # Setup initial pieces
-        setup = [
-            Piece(PieceType.SWORDSMAN, 0),
-            Piece(PieceType.SWORDSMAN, 0),
-            Piece(PieceType.GENERAL, 0),
-            Piece(PieceType.CASTLE, 0),
-            Piece(PieceType.GENERAL, 0),
-            Piece(PieceType.SWORDSMAN, 0),
-            Piece(PieceType.SWORDSMAN, 0),
+        first_row = [
+            PieceType.KNIGHT,
+            PieceType.KNIGHT,
+            PieceType.GENERAL,
+            PieceType.CASTLE,
+            PieceType.GENERAL,
+            PieceType.KNIGHT,
+            PieceType.KNIGHT,
         ]
-        for c, piece in enumerate(setup):
-            self.grid[0][c].piece = piece
-            self.grid[BOARD_HEIGHT - 1][c].piece = Piece(piece.type, 1)
+        for c, t in enumerate(first_row):
+            # IA pieces (player 1) occupy the top of the board
+            self.grid[0][c].piece = Piece(t, 1)
+            # Player pieces (player 0) occupy the bottom
+            self.grid[BOARD_HEIGHT - 1][c].piece = Piece(t, 0)
+
+        for c in range(BOARD_WIDTH):
+            self.grid[1][c].piece = Piece(PieceType.SWORDSMAN, 1)
+            self.grid[BOARD_HEIGHT - 2][c].piece = Piece(PieceType.SWORDSMAN, 0)
 
     def in_bounds(self, r: int, c: int) -> bool:
         return 0 <= r < BOARD_HEIGHT and 0 <= c < BOARD_WIDTH


### PR DESCRIPTION
## Summary
- update starting piece placement
- implement AI personalities with simple opening moves
- document personalities and layout in README

## Testing
- `python -m py_compile medchess/board.py medchess/ai.py`
- `python -m medchess.game -power 1 -max 1` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_684445fcb0208326a8174776d0d13e02