### PR TITLE
Ajout filtre couleurs + commande d'entraînement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,15 @@ Une interface utilisant Tkinter permet de jouer de façon visuelle. Lancez-la av
 python -m medchess.gui [-power N] [-max SECONDES]
 ```
 Les mêmes options `power` et `max` sont disponibles pour ajuster la force du bot.
+
+Les pièces du joueur apparaissent en bleu dans l'interface, celles de l'adversaire en rouge pour mieux les distinguer.
+
+## Entraînement du modèle
+
+Un utilitaire permet d'entraîner le bot manuellement :
+
+```bash
+python -m medchess.train [-max SECONDES]
+```
+
+L'option `-max` limite la durée de l'apprentissage (30 secondes par défaut). Le modèle est sauvegardé dans `medchess/model.zip` et l'entraînement peut être repris en relançant la même commande.

--- a/medchess/gui.py
+++ b/medchess/gui.py
@@ -46,8 +46,17 @@ class GameGUI(tk.Tk):
         }
         for ptype, filename in mapping.items():
             path = os.path.join(img_dir, filename)
-            img = Image.open(path).resize((CELL_SIZE, CELL_SIZE), Image.LANCZOS)
-            self.images[ptype] = ImageTk.PhotoImage(img)
+            base = (
+                Image.open(path)
+                .resize((CELL_SIZE, CELL_SIZE), Image.LANCZOS)
+                .convert("RGBA")
+            )
+            blue_overlay = Image.new("RGBA", base.size, (0, 0, 255, 80))
+            red_overlay = Image.new("RGBA", base.size, (255, 0, 0, 80))
+            blue_img = Image.alpha_composite(base, blue_overlay)
+            red_img = Image.alpha_composite(base, red_overlay)
+            self.images[(ptype, 0)] = ImageTk.PhotoImage(blue_img)
+            self.images[(ptype, 1)] = ImageTk.PhotoImage(red_img)
 
     def draw_board(self) -> None:
         self.canvas.delete("all")
@@ -61,7 +70,7 @@ class GameGUI(tk.Tk):
                 self.canvas.create_rectangle(x1, y1, x2, y2, fill=fill)
                 piece = self.board.get_piece(r, c)
                 if piece:
-                    img = self.images.get(piece.type)
+                    img = self.images.get((piece.type, piece.player))
                     if img:
                         self.canvas.create_image(
                             x1 + CELL_SIZE / 2,
@@ -81,7 +90,7 @@ class GameGUI(tk.Tk):
         piece = self.board.get_piece(fr, fc)
         if not piece:
             return
-        img = self.images.get(piece.type)
+        img = self.images.get((piece.type, piece.player))
         if not img:
             return
         start_x = fc * CELL_SIZE + CELL_SIZE / 2

--- a/medchess/train.py
+++ b/medchess/train.py
@@ -1,0 +1,39 @@
+import argparse
+import os
+import time
+
+from stable_baselines3 import DQN
+from stable_baselines3.dqn import MlpPolicy
+
+from .ai import MedChessEnv
+
+
+def train_model(max_seconds: int) -> None:
+    env = MedChessEnv()
+    model_path = os.path.join(os.path.dirname(__file__), "model.zip")
+    if os.path.exists(model_path):
+        model = DQN.load(model_path, env=env)
+    else:
+        model = DQN(MlpPolicy, env, verbose=0)
+    start = time.time()
+    while True:
+        model.learn(total_timesteps=1000, reset_num_timesteps=False)
+        if time.time() - start >= max_seconds:
+            break
+    model.save(model_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Entraîne le modèle MedChess")
+    parser.add_argument(
+        "-max",
+        type=int,
+        default=30,
+        help="Durée maximale d'entraînement en secondes",
+    )
+    args = parser.parse_args()
+    train_model(args.max)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Résumé
- distingue les pièces des joueurs avec un filtre rouge ou bleu
- ajoute le script `medchess.train` pour entraîner le modèle avec une durée maximale
- documente la nouvelle fonctionnalité dans le README

## Tests
- `python -m py_compile medchess/gui.py medchess/train.py`
- `pip install -r requirements.txt` *(échoue : manque de dépendances GPU)*
- `python -m medchess.train -max 1` *(échoue : module stable_baselines3 absent)*

------
https://chatgpt.com/codex/tasks/task_e_68444e7988908326aab159fc48e0b2e3